### PR TITLE
Add client management feature

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -23,5 +23,10 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="clients">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Clients
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/Components/Pages/Clients.razor
+++ b/Components/Pages/Clients.razor
@@ -1,0 +1,94 @@
+@page "/clients"
+@using CRM.Models
+@inject CRM.Services.ClientService clientService
+
+<h1>Clients</h1>
+
+<EditForm Model="editClient" OnValidSubmit="HandleSubmit">
+    <DataAnnotationsValidator />
+    <div class="mb-3">
+        <InputText @bind-Value="editClient.Name" class="form-control" placeholder="Name" />
+    </div>
+    <div class="mb-3">
+        <InputText @bind-Value="editClient.Email" class="form-control" placeholder="Email" />
+    </div>
+    <button type="submit" class="btn btn-primary me-2">@submitText</button>
+    @if (isEditing)
+    {
+        <button type="button" class="btn btn-secondary" @onclick="CancelEdit">Cancel</button>
+    }
+</EditForm>
+
+<table class="table mt-4">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var c in clients)
+        {
+            <tr>
+                <td>@c.Name</td>
+                <td>@c.Email</td>
+                <td>
+                    <button class="btn btn-sm btn-secondary me-1" @onclick="() => Edit(c)">Edit</button>
+                    <button class="btn btn-sm btn-danger" @onclick="() => Delete(c.Id)">Delete</button>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+@code {
+    private List<Client> clients = new();
+    private Client editClient = new();
+    private bool isEditing;
+
+    protected override void OnInitialized()
+    {
+        clients = clientService.GetClients().ToList();
+    }
+
+    private string submitText => isEditing ? "Update" : "Add";
+
+    private void HandleSubmit()
+    {
+        if (isEditing)
+        {
+            clientService.UpdateClient(editClient);
+        }
+        else
+        {
+            clientService.AddClient(new Client { Name = editClient.Name, Email = editClient.Email });
+        }
+        ResetForm();
+    }
+
+    private void Edit(Client client)
+    {
+        editClient = new Client { Id = client.Id, Name = client.Name, Email = client.Email };
+        isEditing = true;
+    }
+
+    private void Delete(int id)
+    {
+        clientService.DeleteClient(id);
+        ResetForm();
+    }
+
+    private void CancelEdit()
+    {
+        ResetForm();
+    }
+
+    private void ResetForm()
+    {
+        editClient = new Client();
+        isEditing = false;
+        clients = clientService.GetClients().ToList();
+        StateHasChanged();
+    }
+}

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using CRM.Services;
 
 namespace CRM
 {
@@ -15,6 +16,7 @@ namespace CRM
                 });
 
             builder.Services.AddMauiBlazorWebView();
+            builder.Services.AddSingleton<ClientService>();
 
 #if DEBUG
     		builder.Services.AddBlazorWebViewDeveloperTools();

--- a/Models/Client.cs
+++ b/Models/Client.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CRM.Models
+{
+    public class Client
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Name { get; set; } = string.Empty;
+
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/Services/ClientService.cs
+++ b/Services/ClientService.cs
@@ -1,0 +1,36 @@
+using CRM.Models;
+
+namespace CRM.Services
+{
+    public class ClientService
+    {
+        private readonly List<Client> clients = new();
+
+        public IEnumerable<Client> GetClients() => clients;
+
+        public void AddClient(Client client)
+        {
+            client.Id = clients.Count > 0 ? clients.Max(c => c.Id) + 1 : 1;
+            clients.Add(client);
+        }
+
+        public void UpdateClient(Client client)
+        {
+            var existing = clients.FirstOrDefault(c => c.Id == client.Id);
+            if (existing != null)
+            {
+                existing.Name = client.Name;
+                existing.Email = client.Email;
+            }
+        }
+
+        public void DeleteClient(int id)
+        {
+            var client = clients.FirstOrDefault(c => c.Id == id);
+            if (client != null)
+            {
+                clients.Remove(client);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Client` model and simple in-memory `ClientService`
- create `Clients` page with add, edit and delete form
- register `ClientService` in `MauiProgram`
- add navigation link to Clients page

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684bf59ea784832bba6e271803a00ed3