### PR TITLE
Add NotFound route

### DIFF
--- a/Components/Routes.razor
+++ b/Components/Routes.razor
@@ -1,6 +1,11 @@
-﻿<Router AppAssembly="@typeof(MauiProgram).Assembly">
+<Router AppAssembly="@typeof(MauiProgram).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(Layout.MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
 </Router>


### PR DESCRIPTION
## Summary
- add a NotFound route with a simple message to improve navigation feedback

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ef1d44984832bb7f4262b3a255ffa